### PR TITLE
Hotfix/switch wallet chains

### DIFF
--- a/apps/front-end/src/providers/StableProvider.tsx
+++ b/apps/front-end/src/providers/StableProvider.tsx
@@ -9,7 +9,7 @@ import {
   type PropsWithChildren,
   type JSX,
 } from "react";
-import { WalletClient } from "viem";
+import type { WalletClient } from "viem";
 
 interface StableContextValue {
   address?: string;

--- a/apps/front-end/src/providers/StableProvider.tsx
+++ b/apps/front-end/src/providers/StableProvider.tsx
@@ -9,6 +9,7 @@ import {
   type PropsWithChildren,
   type JSX,
 } from "react";
+import { WalletClient } from "viem";
 
 interface StableContextValue {
   address?: string;
@@ -30,8 +31,15 @@ export const StableProvider = ({
       primaryWallet && isEthereumWallet(primaryWallet)
         ? {
             platform: "Evm" as const,
-            getWalletClient: (chain) =>
-              primaryWallet.getWalletClient(chain.id.toString(10)),
+            getWalletClient: async (chain): Promise<WalletClient> => {
+              const walletClient = await primaryWallet.getWalletClient(
+                chain.id.toString(10),
+              );
+              if ((await walletClient.getChainId()) !== chain.id) {
+                await walletClient.switchChain(chain);
+              }
+              return walletClient;
+            },
           }
         : undefined,
     [primaryWallet],

--- a/packages/stable-sdk/src/methods/executeRoute/executeRouteSteps.ts
+++ b/packages/stable-sdk/src/methods/executeRoute/executeRouteSteps.ts
@@ -20,7 +20,6 @@ const fromGwei = (gwei: number) => evmGasToken(gwei, "nEvmGasToken").toUnit("ato
 export async function executeRouteSteps<N extends Network, D extends keyof EvmDomains>(
   network: N, route: Route, signer: ViemWalletClient, client: ViemEvmClient<N, D>,
 ): Promise<TxHash[]> {
-  const viemChainId = viemChainOf[network][route.intent.sourceChain].id;
   const txHashes = [] as string[];
   let permit: Permit | undefined = undefined;
   while (true) {
@@ -31,12 +30,6 @@ export async function executeRouteSteps<N extends Network, D extends keyof EvmDo
 
     if (stepType !== "sign-permit" && isContractTx(txOrSig)) {
       const txParameters = buildEvmTxParameters(txOrSig, signer.chain!, signer.account!);
-      // @note: This method is defined on some wallets but not all
-      try {
-        await signer.switchChain({ id: viemChainId });
-      } catch (error) {
-        console.error("Failed to switch chain:", error);
-      }
       const tx = await signer.sendTransaction(txParameters);
 
       route.transactionListener.emit("transaction-sent", parseTxSentEventData(tx, txParameters));
@@ -55,7 +48,7 @@ export async function executeRouteSteps<N extends Network, D extends keyof EvmDo
       });
 
       permit = {
-        signature: Buffer.from(encoding.stripPrefix("0x", signature), "hex"),
+        signature: encoding.hex.decode(signature),
         // It's possible to override the following values by changing them
         // before signing the message.
         // We need to pass them back to the cctp-sdk so that it can know

--- a/packages/stable-sdk/src/stable.ts
+++ b/packages/stable-sdk/src/stable.ts
@@ -31,13 +31,7 @@ export class StableSDK<N extends Network> extends SDK<N> {
   public async getSigner(domain: keyof EvmDomains): ReturnType<SDK<N>["getSigner"]> {
     const viemChain = viemChainOf[this.options.network][domain];
     const rpcUrl = this.getRpcUrl(domain);
-    const signer = await this.options.signer.getWalletClient(viemChain, rpcUrl);
-
-    if (await signer.getChainId() !== viemChain.id) {
-      await signer.switchChain(viemChain);
-    }
-
-    return signer;
+    return this.options.signer.getWalletClient(viemChain, rpcUrl);
   }
 
   /**

--- a/packages/stable-sdk/src/stable.ts
+++ b/packages/stable-sdk/src/stable.ts
@@ -36,7 +36,7 @@ export class StableSDK<N extends Network> extends SDK<N> {
     if (await signer.getChainId() !== viemChain.id) {
       await signer.switchChain(viemChain);
     }
-    
+
     return signer;
   }
 

--- a/packages/stable-sdk/src/stable.ts
+++ b/packages/stable-sdk/src/stable.ts
@@ -28,10 +28,16 @@ export class StableSDK<N extends Network> extends SDK<N> {
   /**
    * @returns The viem wallet client of the user
    */
-  public getSigner(domain: keyof EvmDomains): ReturnType<SDK<N>["getSigner"]> {
+  public async getSigner(domain: keyof EvmDomains): ReturnType<SDK<N>["getSigner"]> {
     const viemChain = viemChainOf[this.options.network][domain];
     const rpcUrl = this.getRpcUrl(domain);
-    return this.options.signer.getWalletClient(viemChain, rpcUrl);
+    const signer = await this.options.signer.getWalletClient(viemChain, rpcUrl);
+
+    if (await signer.getChainId() !== viemChain.id) {
+      await signer.switchChain(viemChain);
+    }
+    
+    return signer;
   }
 
   /**


### PR DESCRIPTION
Check if the wallet is connected to the right node during instantiation.
If it's not, then call switch chain.
In theory switch chain will never be called for instances of the sdk running on a backend.