### PR TITLE
Display estimated cost in route summary

### DIFF
--- a/apps/front-end/src/components/compounds/BridgeWidget/BridgeWidget.tsx
+++ b/apps/front-end/src/components/compounds/BridgeWidget/BridgeWidget.tsx
@@ -1,4 +1,4 @@
-import type { Duration } from "@stable-io/cctp-sdk-definitions";
+import type { Route } from "@stable-io/sdk";
 import type { ReactElement } from "react";
 
 import {
@@ -23,7 +23,7 @@ interface BridgeWidgetProps {
   availableChains: readonly AvailableChains[];
   walletAddress?: string;
   balance: number;
-  route?: { corridor: string; estimatedDuration: Duration } | undefined;
+  route?: Route<AvailableChains, AvailableChains>;
   isInProgress: boolean;
   onTransfer: () => void;
 }

--- a/apps/front-end/src/components/elements/RouteInformation/RouteInformation.tsx
+++ b/apps/front-end/src/components/elements/RouteInformation/RouteInformation.tsx
@@ -1,13 +1,15 @@
-import type { Duration } from "@stable-io/cctp-sdk-definitions";
+import type { Route } from "@stable-io/sdk";
 import Image from "next/image";
 import type { ReactElement } from "react";
 
 import { RouteMetaItem } from "./RouteMetaItem";
 
 import { SectionDivider, SplitLayout } from "@/components";
+import type { AvailableChains } from "@/constants";
+import { formatCost } from "@/utils";
 
 interface RouteInformationProps {
-  route?: { corridor: string; estimatedDuration: Duration } | undefined;
+  route?: Route<AvailableChains, AvailableChains>;
 }
 
 export const RouteInformation = ({
@@ -17,7 +19,7 @@ export const RouteInformation = ({
     return undefined;
   }
 
-  const { corridor, estimatedDuration } = route;
+  const { corridor, estimatedDuration, estimatedTotalCost } = route;
 
   const leftContent = (
     <>
@@ -38,7 +40,11 @@ export const RouteInformation = ({
 
   const rightContent = (
     <>
-      <RouteMetaItem iconSrc="/imgs/gas.svg" altText="Gas fees" value="$3.20" />
+      <RouteMetaItem
+        iconSrc="/imgs/gas.svg"
+        altText="Gas fees"
+        value={formatCost(estimatedTotalCost)}
+      />
       <RouteMetaItem
         iconSrc="/imgs/time.svg"
         altText="Duration"

--- a/apps/front-end/src/pages/bridge.tsx
+++ b/apps/front-end/src/pages/bridge.tsx
@@ -1,4 +1,3 @@
-import type { Route } from "@stable-io/sdk";
 import Head from "next/head";
 import { useState } from "react";
 import type { ReactElement } from "react";
@@ -17,6 +16,7 @@ import { availableChains } from "@/constants";
 import { useBalance, useRoutes, useTransferProgress } from "@/hooks";
 import { useStableContext } from "@/providers";
 import type { NextPageWithLayout } from "@/utils";
+import { formatCost } from "@/utils";
 
 const Bridge: NextPageWithLayout = (): ReactElement => {
   const [amount, setAmount] = useState(0);
@@ -47,12 +47,6 @@ const Bridge: NextPageWithLayout = (): ReactElement => {
     dismiss,
     steps,
   } = useTransferProgress(route);
-
-  const formatCost = (
-    cost: Route<AvailableChains, AvailableChains>["estimatedTotalCost"],
-  ): string => {
-    return `$${cost.toUnit("human")}`;
-  };
 
   // @todo: Subtract expected fees
   // const maxAmount = balance;

--- a/apps/front-end/src/utils.ts
+++ b/apps/front-end/src/utils.ts
@@ -1,4 +1,4 @@
-import type { Network } from "@stable-io/sdk";
+import type { Network, Route } from "@stable-io/sdk";
 import type { NextPage } from "next";
 import type { ReactElement, ReactNode } from "react";
 
@@ -14,6 +14,12 @@ export const formatNumber = (num: number): string =>
     maximumFractionDigits: 6,
     minimumFractionDigits: 0,
   });
+
+export const formatCost = (
+  cost: Route<any, any>["estimatedTotalCost"],
+): string => {
+  return `$${cost.toUnit("human").toFixed(2)}`;
+};
 
 const bigintReplacer = (key: string, value: unknown): unknown =>
   typeof value === "bigint" ? value.toString() : value;


### PR DESCRIPTION
This was already displayed in the transaction tracking widget.